### PR TITLE
Allow mismatched head when loading MMS LID model

### DIFF
--- a/finetune_mms_lid.py
+++ b/finetune_mms_lid.py
@@ -270,11 +270,16 @@ def main():
     label2id = {label: i for i, label in id2label.items()}
 
     logger.info("Loading model %s", model_name)
+    logger.info(
+        "Initializing classification head with %d labels and ignoring mismatched head weights",
+        len(LANG_LABELS),
+    )
     model = AutoModelForAudioClassification.from_pretrained(
         model_name,
         num_labels=len(LANG_LABELS),
         id2label=id2label,
         label2id=label2id,
+        ignore_mismatched_sizes=True,
     )
 
     if config.freeze_feature_extractor:


### PR DESCRIPTION
## Summary
- log the initialization of the reduced classification head when loading the MMS LID backbone
- allow the pretrained model to ignore mismatched head weights so the 3-class head is retained

## Testing
- python finetune_mms_lid.py --train-manifest data/train_manifest.json --validation-split 0 --output-dir tmp-output --num-train-epochs 0.0 --save-steps 1 --logging-steps 1 --max-train-samples 1 --dataloader-num-workers 0 --preprocessing-num-workers 1 *(fails: blocked from downloading facebook/mms-lid-126 due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e41d67802483229e47a1c32cb7a409