### PR TITLE
Support JSONL manifests for data loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Usage
 ```
 python finetune_mms_lid.py
---train-manifest ../manifests/data_train_0930.json
---eval-manifest ../manifests/data_valid_0930.json
+--train-manifest ../manifests/data_train_0930.jsonl
+--eval-manifest ../manifests/data_valid_0930.jsonl
 --per-device-train-batch-size 2
 --per-device-eval-batch-size 2
 --initialize-other-from-average

--- a/launch.py
+++ b/launch.py
@@ -21,8 +21,8 @@ estimator = PyTorch(
     # environment={"TOKENIZERS_PARALLELISM": "false"},
     hyperparameters={
         # read manifests and audio directly from S3
-        "train-manifest": "s3://us-west-2-ehmli/lid-job/manifests/data_train_0930.s3.json",
-        "eval-manifest":  "s3://us-west-2-ehmli/lid-job/manifests/data_valid_0930.s3.json",
+        "train-manifest": "s3://us-west-2-ehmli/lid-job/manifests/data_train_0930.s3.jsonl",
+        "eval-manifest":  "s3://us-west-2-ehmli/lid-job/manifests/data_valid_0930.s3.jsonl",
         "num-epochs": 10,
         "batch-size": 8,
         "lr": 1e-4,


### PR DESCRIPTION
## Summary
- update both training entrypoints to parse JSONL manifests and normalize required fields
- refresh documentation and launch configuration to point to .jsonl manifests

## Testing
- python -m compileall src/train_sm.py finetune_mms_lid.py

------
https://chatgpt.com/codex/tasks/task_e_68e4367db474832287922f581d940feb