### PR TITLE
Handle string boolean hyperparameters in fine-tuning script

### DIFF
--- a/finetune_mms_lid.py
+++ b/finetune_mms_lid.py
@@ -236,6 +236,21 @@ class FinetuneConfig:
     initialize_other_from_average: bool
 
 
+def _strtobool(value):
+    """Interpret common string representations of boolean values."""
+
+    if isinstance(value, bool):
+        return value
+
+    normalized = str(value).lower()
+    if normalized in {"true", "1", "yes", "y"}:
+        return True
+    if normalized in {"false", "0", "no", "n"}:
+        return False
+
+    raise argparse.ArgumentTypeError(f"Expected a boolean value, got '{value}'.")
+
+
 def parse_args() -> FinetuneConfig:
     parser = argparse.ArgumentParser(description="Fine-tune facebook/mms-lid-126")
     parser.add_argument(
@@ -273,15 +288,28 @@ def parse_args() -> FinetuneConfig:
     )
     parser.add_argument("--save-total-limit", type=int, default=2)
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--fp16", action="store_true", help="Enable FP16 training.")
+    parser.add_argument(
+        "--fp16",
+        nargs="?",
+        const=True,
+        default=False,
+        type=_strtobool,
+        help="Enable FP16 training.",
+    )
     parser.add_argument(
         "--freeze-feature-extractor",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        type=_strtobool,
         help="Freeze the convolutional feature extractor of the backbone.",
     )
     parser.add_argument(
         "--train-classifier-only",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        type=_strtobool,
         help="Freeze all model parameters except the classification head.",
     )
     parser.add_argument(
@@ -316,7 +344,10 @@ def parse_args() -> FinetuneConfig:
     )
     parser.add_argument(
         "--initialize-other-from-average",
-        action="store_true",
+        nargs="?",
+        const=True,
+        default=False,
+        type=_strtobool,
         help=(
             "Initialize the 'other' classification head using the average of selected"
             " MMS LID languages (East and Southeast Asia, excluding China)."

--- a/launch_finetune.py
+++ b/launch_finetune.py
@@ -1,0 +1,68 @@
+"""Launch a SageMaker training job for finetune_mms_lid.py."""
+import sagemaker
+from sagemaker.inputs import TrainingInput
+from sagemaker.pytorch import PyTorch
+from sagemaker import image_uris
+
+role = sagemaker.get_execution_role()
+
+# Resolve the latest PyTorch DLC for training on GPU instances.
+image_uri = image_uris.retrieve(
+    framework="pytorch",
+    version="2.0.1",
+    py_version="py310",
+    instance_type="ml.g5.2xlarge",
+    image_scope="training",
+    region=sagemaker.Session().boto_region_name,
+)
+
+estimator = PyTorch(
+    entry_point="finetune_mms_lid.py",
+    source_dir=".",
+    role=role,
+    instance_type="ml.g5.2xlarge",
+    instance_count=1,
+    framework_version="2.0.1",
+    py_version="py310",
+    image_uri=image_uri,
+    volume_size=200,  # GB; ensure there is space for audio + checkpoints
+    max_run=12 * 3600,
+    hyperparameters={
+        # The manifests are expected to live inside the corresponding data channels.
+        "train-manifest": "/opt/ml/input/data/training/train_manifest.jsonl",
+        "eval-manifest": "/opt/ml/input/data/validation/valid_manifest.jsonl",
+        "output-dir": "/opt/ml/model",
+        "num-train-epochs": 5,
+        "learning-rate": 2e-5,
+        "per-device-train-batch-size": 8,
+        "per-device-eval-batch-size": 8,
+        "gradient-accumulation-steps": 2,
+        "warmup-steps": 500,
+        "weight-decay": 0.01,
+        "logging-steps": 100,
+        "save-steps": 500,
+        "eval-steps": 500,
+        "save-total-limit": 2,
+        "fp16": True,
+        "freeze-feature-extractor": True,
+        "initialize-other-from-average": True,
+        "dataloader-num-workers": 4,
+        "preprocessing-num-workers": 4,
+    },
+    dependencies=["requirements.txt"],
+)
+
+inputs = {
+    "training": TrainingInput(
+        s3_data="s3://my-bucket/path/to/training/",  # contains train_manifest.jsonl + audio files
+        distribution="FullyReplicated",
+        content_type="application/json",
+    ),
+    "validation": TrainingInput(
+        s3_data="s3://my-bucket/path/to/validation/",  # contains valid_manifest.jsonl + audio files
+        distribution="FullyReplicated",
+        content_type="application/json",
+    ),
+}
+
+estimator.fit(inputs=inputs)


### PR DESCRIPTION
## Summary
- allow boolean CLI flags such as `--fp16` to accept optional string values
- ensure SageMaker hyperparameter injection of `True`/`False` no longer breaks argument parsing

## Testing
- python -m compileall finetune_mms_lid.py

------
https://chatgpt.com/codex/tasks/task_e_68e4be1f195c8322a06959ce182e10f9