### PR TITLE
Add configurable preprocessing batch size for dataset preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ python finetune_mms_lid.py
 --eval-manifest ../manifests/data_valid_0930.json
 --per-device-train-batch-size 2
 --per-device-eval-batch-size 2
+--preprocessing-batch-size 16
 --initialize-other-from-average
 --fp16
 ```

--- a/src/finetune_mms_lid.py
+++ b/src/finetune_mms_lid.py
@@ -234,6 +234,7 @@ class FinetuneConfig:
     max_eval_samples: Optional[int]
     dataloader_num_workers: int
     preprocessing_num_workers: int
+    preprocessing_batch_size: int
     initialize_other_from_average: bool
 
 
@@ -342,6 +343,15 @@ def parse_args() -> FinetuneConfig:
         type=int,
         default=4,
         help="Number of worker processes to use during dataset preprocessing steps.",
+    )
+    parser.add_argument(
+        "--preprocessing-batch-size",
+        type=int,
+        default=16,
+        help=(
+            "Batch size to use during dataset preprocessing map operations."
+            " Tune based on available CPU and memory."
+        ),
     )
     parser.add_argument(
         "--initialize-other-from-average",
@@ -506,6 +516,7 @@ def build_dataset_dict(config: FinetuneConfig, feature_extractor) -> DatasetDict
             batched=True,
             remove_columns=remove_cols,
             num_proc=num_proc,
+            batch_size=config.preprocessing_batch_size,
         )
         datasets[split].set_format(type="torch")
 


### PR DESCRIPTION
## Summary
- add a preprocessing batch size option to `FinetuneConfig` and expose it via the CLI
- use the configured batch size when running dataset preprocessing maps and document the knob in the README

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68e56f2433408322be2be263ba394e07